### PR TITLE
Declare some variables "extern" to fix multiple definition errors

### DIFF
--- a/culfw/clib/rf_receive_bucket.c
+++ b/culfw/clib/rf_receive_bucket.c
@@ -23,6 +23,8 @@
 #include <avr/io.h>                     // for _BV
 #include <stdint.h>                     // for uint8_t
 
+packetCheckValues_t packetCheckValues[NUM_SLOWRF];
+
 uint8_t makeavg(uint8_t i, uint8_t j)
 {
   return (i+i+i+j)/4;

--- a/culfw/clib/rf_receive_bucket.h
+++ b/culfw/clib/rf_receive_bucket.h
@@ -75,12 +75,13 @@ typedef struct  {
 /*
  * This struct has the bits for receive check
  */
-struct {
+typedef struct {
    uint8_t isrep:1; // 1 Bit for is repeated
    uint8_t isnotrep:1; // 1 Bit for is repeated value
    uint8_t packageOK:1; // Received packet is ok
    // 5 bits free
-} packetCheckValues[NUM_SLOWRF];
+} packetCheckValues_t;
+extern packetCheckValues_t packetCheckValues[NUM_SLOWRF];
 
 
 /*

--- a/culfw/clib/ttydata.c
+++ b/culfw/clib/ttydata.c
@@ -13,6 +13,7 @@
 #endif
 
 void (*input_handle_func)(uint8_t channel);
+void (*output_flush_func)(void);
 
 
 rb_t TTY_Tx_Buffer;

--- a/culfw/clib/ttydata.h
+++ b/culfw/clib/ttydata.h
@@ -13,8 +13,8 @@ typedef struct _fntab {
 void analyze_ttydata(uint8_t channel);
 uint8_t callfn(char *buf);
 
-void (*input_handle_func)(uint8_t channel);
-void (*output_flush_func)(void);
+extern void (*input_handle_func)(uint8_t channel);
+extern void (*output_flush_func)(void);
 
 extern rb_t TTY_Tx_Buffer;
 extern rb_t TTY_Rx_Buffer;


### PR DESCRIPTION
Each global variable has to be defined exactly once, declarations need the extern keyword.

Move the packetCheckValues definition to rf_receive_bucket.c, likewise for the output_flush_func callback.